### PR TITLE
Fix PyCharm Run Configurations and add PEP8 Style Checking

### DIFF
--- a/.idea/AgTern.iml
+++ b/.idea/AgTern.iml
@@ -11,4 +11,7 @@
     <option name="format" value="PLAIN" />
     <option name="myDocStringFormat" value="Plain" />
   </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
 </module>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
-    <inspection_tool class="PyPep8Inspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="ERROR" enabled_by_default="true" editorAttributes="ERRORS_ATTRIBUTES" />
   </profile>
 </component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,6 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <settings>
-    <option name="USE_PROJECT_PROFILE" value="false" />
-    <version value="1.0" />
-  </settings>
-</component>

--- a/.idea/runConfigurations/AgTern.xml
+++ b/.idea/runConfigurations/AgTern.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="AgTern" type="PythonConfigurationType" factoryName="Python">
     <module name="AgTern" />
-    <option name="INTERPRETER_OPTIONS" value="-m" />
+    <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
@@ -16,7 +16,7 @@
     <option name="PARAMETERS" value="" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
-    <option name="MODULE_MODE" value="false" />
+    <option name="MODULE_MODE" value="true" />
     <option name="REDIRECT_INPUT" value="false" />
     <option name="INPUT_FILE" value="" />
     <method v="2" />

--- a/.idea/runConfigurations/AgTern.xml
+++ b/.idea/runConfigurations/AgTern.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="AgTern" type="PythonConfigurationType" factoryName="Python">
     <module name="AgTern" />
-    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="INTERPRETER_OPTIONS" value="-m" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
@@ -12,7 +12,7 @@
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
-    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/agtern.py" />
+    <option name="SCRIPT_NAME" value="agtern" />
     <option name="PARAMETERS" value="" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />

--- a/.idea/runConfigurations/AgTern__No_Scrape_.xml
+++ b/.idea/runConfigurations/AgTern__No_Scrape_.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="AgTern (No Scrape)" type="PythonConfigurationType" factoryName="Python">
     <module name="AgTern" />
-    <option name="INTERPRETER_OPTIONS" value="-m" />
+    <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
@@ -16,7 +16,7 @@
     <option name="PARAMETERS" value="--noscrape" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
-    <option name="MODULE_MODE" value="false" />
+    <option name="MODULE_MODE" value="true" />
     <option name="REDIRECT_INPUT" value="false" />
     <option name="INPUT_FILE" value="" />
     <method v="2" />

--- a/.idea/runConfigurations/AgTern__No_Scrape_.xml
+++ b/.idea/runConfigurations/AgTern__No_Scrape_.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Import Companies" type="PythonConfigurationType" factoryName="Python">
+  <configuration default="false" name="AgTern (No Scrape)" type="PythonConfigurationType" factoryName="Python">
     <module name="AgTern" />
-    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="INTERPRETER_OPTIONS" value="-m" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
@@ -12,8 +12,8 @@
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
-    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/agtern.py" />
-    <option name="PARAMETERS" value="import-companies" />
+    <option name="SCRIPT_NAME" value="agtern" />
+    <option name="PARAMETERS" value="--noscrape" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/.idea/runConfigurations/AgTern__Show_Scraper_.xml
+++ b/.idea/runConfigurations/AgTern__Show_Scraper_.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="AgTern (Show Scraper)" type="PythonConfigurationType" factoryName="Python">
     <module name="AgTern" />
-    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="INTERPRETER_OPTIONS" value="-m" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
@@ -12,7 +12,7 @@
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
-    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/agtern.py" />
+    <option name="SCRIPT_NAME" value="agtern" />
     <option name="PARAMETERS" value="--show-scraper" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />

--- a/.idea/runConfigurations/AgTern__Show_Scraper_.xml
+++ b/.idea/runConfigurations/AgTern__Show_Scraper_.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="AgTern (Show Scraper)" type="PythonConfigurationType" factoryName="Python">
     <module name="AgTern" />
-    <option name="INTERPRETER_OPTIONS" value="-m" />
+    <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
@@ -16,7 +16,7 @@
     <option name="PARAMETERS" value="--show-scraper" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
-    <option name="MODULE_MODE" value="false" />
+    <option name="MODULE_MODE" value="true" />
     <option name="REDIRECT_INPUT" value="false" />
     <option name="INPUT_FILE" value="" />
     <method v="2" />

--- a/.idea/runConfigurations/AgTern__Update_Companies_.xml
+++ b/.idea/runConfigurations/AgTern__Update_Companies_.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Sort Companies" type="PythonConfigurationType" factoryName="Python">
+  <configuration default="false" name="AgTern (Update Companies)" type="PythonConfigurationType" factoryName="Python">
     <module name="AgTern" />
-    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="INTERPRETER_OPTIONS" value="-m" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
@@ -12,8 +12,8 @@
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
-    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/agtern.py" />
-    <option name="PARAMETERS" value="sort-companies" />
+    <option name="SCRIPT_NAME" value="agtern" />
+    <option name="PARAMETERS" value="--update-companies" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/.idea/runConfigurations/AgTern__Update_Companies_.xml
+++ b/.idea/runConfigurations/AgTern__Update_Companies_.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="AgTern (Update Companies)" type="PythonConfigurationType" factoryName="Python">
     <module name="AgTern" />
-    <option name="INTERPRETER_OPTIONS" value="-m" />
+    <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
@@ -16,7 +16,7 @@
     <option name="PARAMETERS" value="--update-companies" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
-    <option name="MODULE_MODE" value="false" />
+    <option name="MODULE_MODE" value="true" />
     <option name="REDIRECT_INPUT" value="false" />
     <option name="INPUT_FILE" value="" />
     <method v="2" />


### PR DESCRIPTION
### Closes #39
- Fixed PyCharm Run Configurations
- PyCharm now detects PEP8 style violations as errors and marks them with red squiggles:
![image](https://user-images.githubusercontent.com/34139712/195953630-710eb68a-9660-43e1-9ad6-c81ce7c39864.png)
- These settings are automatically applied when you open the project in PyCharm