### PR TITLE
Favicon.ico

### DIFF
--- a/agtern/utils.py
+++ b/agtern/utils.py
@@ -1,3 +1,5 @@
+import tkinter
+
 import selenium.webdriver.support.expected_conditions as condition
 from selenium.webdriver.common.by import By
 import tkinter as tk
@@ -12,12 +14,6 @@ def getfavicon(usedUrl):
         if (domainServer != url):
             break
     domainServer += "/favicon.ico"
-    return(domainServer)
-url = getfavicon(url)
-print("A")
-print(url)
-#Currently obtains the root favicon.ico link
+    image = tk.PhotoImage(file=domainServer)
+    return(image)
 
-#Left to do:
-# Save from the website the .assets folder
-# Return the file address

--- a/agtern/utils.py
+++ b/agtern/utils.py
@@ -3,7 +3,7 @@ import tkinter
 import selenium.webdriver.support.expected_conditions as condition
 from selenium.webdriver.common.by import By
 import tkinter as tk
-url = 'google.com/shmeepshmop'
+url = 'google.com/images'
 extensions = ['.com', '.net', '.org', '.eu', '.info', '.uk', '.gov']
 domainServer = ''
 

--- a/agtern/utils.py
+++ b/agtern/utils.py
@@ -1,0 +1,23 @@
+import selenium.webdriver.support.expected_conditions as condition
+from selenium.webdriver.common.by import By
+import tkinter as tk
+url = 'google.com/shmeepshmop'
+extensions = ['.com', '.net', '.org', '.eu', '.info', '.uk']
+domainServer = ''
+
+def getfavicon(usedUrl):
+    for i in range(len(extensions)):
+        stringSplit = (usedUrl.find(extensions[i])) + (len(extensions[i]))
+        domainServer = usedUrl[:stringSplit]
+        if (domainServer != url):
+            break
+    domainServer += "/favicon.ico"
+    return(domainServer)
+url = getfavicon(url)
+print("A")
+print(url)
+#Currently obtains the root favicon.ico link
+
+#Left to do:
+# Save from the website the .assets folder
+# Return the file address

--- a/agtern/utils.py
+++ b/agtern/utils.py
@@ -1,19 +1,52 @@
 import tkinter
-
 import selenium.webdriver.support.expected_conditions as condition
 from selenium.webdriver.common.by import By
 import tkinter as tk
-url = 'google.com/images'
-extensions = ['.com', '.net', '.org', '.eu', '.info', '.uk', '.gov']
-domainServer = ''
-
+from urllib.request import urlopen
+url = str(input("Enter the url here:"))
 def getfavicon(usedUrl):
+    extensions = ['.com', '.net', '.org', '.eu', '.info', '.uk', '.gov']
+    domainServer = ''
+    image_links = []
+    split_image = []
+#Find the Domain Server via the Given Link
     for i in range(len(extensions)):
         stringSplit = (usedUrl.find(extensions[i])) + (len(extensions[i]))
         domainServer = usedUrl[:stringSplit]
         if (domainServer != url):
             break
-    domainServer += "/favicon.ico"
-    image = tk.PhotoImage(file=domainServer)
-    return(image)
+#Read the HTML Data from the domain server
+    page = urlopen(domainServer)
+    html_raw_data = str(page.read())
+#Find all instances of rel="icon" (rel="icon" is not included in the list element)
+    rel_icons = (html_raw_data.split('<link rel="icon"'))
+#Sort data based on the two most common ways of storing the file
+    for i in range(len(rel_icons)):
+        temp = rel_icons[i]
+        temp_parts = temp.split('href="')
+        for i in range(len(temp_parts)):
+            if ((temp.find(".png") > temp.find(".ico"))):
+                image_links.append(temp[7:temp.find(".png") + 4])
+                break
+            if (temp.find(".png") < temp.find(".ico")):
+                image_links.append(temp[7:temp.find(".ico") + 4])
+                break
+#Break the current data segments into segments using the likeliest data tags
+    for i in range(len(image_links)):
+        temporary = str(image_links)
+        split_image += temporary.split('content="')
+    for i in range(len(split_image)):
+        temp = str(split_image[i])
+        split_temp = temp.split('href="')
+#Look for an open-ended file directory, then append it to the domain server.
+        for i in range(len(split_temp)):
+            if temp[0] == '/':
+                image_source_files.append(domainServer + temp[:temp.find('.png')+4])
+    image_links += image_source_files
+    return(image_links[-1])
 
+
+
+#To-Do:
+#Notify the Discord of the lengthy runtime, ask if it would be used to save the image links/files on the server.
+print(getfavicon(url))

--- a/agtern/utils.py
+++ b/agtern/utils.py
@@ -4,7 +4,7 @@ import selenium.webdriver.support.expected_conditions as condition
 from selenium.webdriver.common.by import By
 import tkinter as tk
 url = 'google.com/shmeepshmop'
-extensions = ['.com', '.net', '.org', '.eu', '.info', '.uk']
+extensions = ['.com', '.net', '.org', '.eu', '.info', '.uk', '.gov']
 domainServer = ''
 
 def getfavicon(usedUrl):


### PR DESCRIPTION
Closes #21 

This is in a Draft State, but has functionality for most websites.

Splices the host URL based on the most common web extensions, and returns the link of the favicon.ico file commonly stored at that location. I am currently looking into ways to download images directly rather than using the link.