### PR TITLE
Scrape more companies

### DIFF
--- a/backend/app/models/internships.py
+++ b/backend/app/models/internships.py
@@ -20,3 +20,10 @@ class Internship(DatabaseModel):
     description = Column(String)
     # TODO: Add tags to the model, see https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.ARRAY
     # (we would have to use the PostgreSQL backend)
+
+    def __str__(self):
+        return str({
+            column: getattr(self, column)
+            for column in DatabaseInternship.__table__.columns.keys()
+            if hasattr(self, column)
+        })

--- a/backend/app/models/internships.py
+++ b/backend/app/models/internships.py
@@ -15,15 +15,19 @@ class Internship(DatabaseModel):
     apply_link = Column(String)
     period = Column(String, index=True)
     year = Column(String, index=True)
-    post_date = Column(String)  # TODO: Store this as a date (date strings are all different formats right now)
+    post_date = Column(
+        String
+    )  # TODO: Store this as a date (date strings are all different formats right now)
     location = Column(String, index=True)
     description = Column(String)
     # TODO: Add tags to the model, see https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.ARRAY
     # (we would have to use the PostgreSQL backend)
 
     def __str__(self):
-        return str({
-            column: getattr(self, column)
-            for column in DatabaseInternship.__table__.columns.keys()
-            if hasattr(self, column)
-        })
+        return str(
+            {
+                column: getattr(self, column)
+                for column in Internship.__table__.columns.keys()
+                if hasattr(self, column)
+            }
+        )

--- a/backend/app/models/internships.py
+++ b/backend/app/models/internships.py
@@ -7,10 +7,16 @@ class Internship(DatabaseModel):
     __tablename__ = "internships"
 
     id = Column(Integer, primary_key=True, index=True)
+    job_id = Column(String, index=True)
     company = Column(String, index=True)
     title = Column(String, index=True)
-    year = Column(String, index=True)
-    period = Column(String, index=True)
+    category = Column(String, index=True)
     link = Column(String)
+    apply_link = Column(String)
+    period = Column(String, index=True)
+    year = Column(String, index=True)
+    post_date = Column(String)  # TODO: Store this as a date (date strings are all different formats right now)
     location = Column(String, index=True)
     description = Column(String)
+    # TODO: Add tags to the model, see https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.ARRAY
+    # (we would have to use the PostgreSQL backend)

--- a/backend/app/schemas/internships.py
+++ b/backend/app/schemas/internships.py
@@ -19,11 +19,15 @@ class InternshipBase(BaseModel):
     id: Union[
         int, None
     ] = None  # Auto-incremented primary key, leave None for automatic id
+    job_id: str = ""
     company: str = ""
     title: str = ""
+    category: str = ""
     link: str = ""
+    apply_link: str = ""
     period: Season = Season.unknown
     year: int = 0
+    post_date: str = ""  # See models.py on why this is a string
     location: str = ""
     description: str = ""
 

--- a/backend/app/scraping/actions/models.py
+++ b/backend/app/scraping/actions/models.py
@@ -127,6 +127,7 @@ class DataType(str, Enum):
 class ScrapePropertyModel(ScrapeActionModel):
     xpath: str = None
     value: str = None  # Constant string to use as a column value
+    loading_text: str = None
     html_property: str = "innerText"
     regex: RegexConfigModel = None
     store_as: DataType = DataType.str

--- a/backend/app/scraping/actions/models.py
+++ b/backend/app/scraping/actions/models.py
@@ -83,11 +83,6 @@ class RegexConfigModel(BaseModel):
             )
         return values
 
-    @root_validator(pre=True)
-    def validate_default(cls, values):
-        values["_use_default_on_failure"] = "default" in values
-        return values
-
     @root_validator(skip_on_failure=True)
     def validate(cls, values):
         if "pattern" in values:

--- a/backend/app/scraping/actions/models.py
+++ b/backend/app/scraping/actions/models.py
@@ -105,6 +105,7 @@ class RegexConfigModel(BaseModel):
                 if flag in values:
                     flags |= all_flags[flag]
             values["_flags"] = flags
+            values["_use_default_on_failure"] = "default" in values
             values["pattern"] = re.compile(values["pattern"], flags)
             return RegexConfigModel.construct(**values)
 

--- a/backend/app/scraping/actions/scrape_actions.py
+++ b/backend/app/scraping/actions/scrape_actions.py
@@ -7,7 +7,7 @@ from typing import Callable, List
 import pandas as pd
 from pydantic import AnyUrl
 from selenium.common import NoSuchElementException, TimeoutException
-from selenium.webdriver import ActionChains
+from selenium.webdriver import ActionChains, Keys
 
 from backend.app.utils import LOG
 
@@ -61,9 +61,9 @@ def click(ctx: ScrapingContext, xpath: str, must_exist: bool = True):
 @scrape_action("type")
 def type(ctx: ScrapingContext, xpath: str, text: str):
     # TODO: Delay in between keystrokes
-    ActionChains(ctx.scraper.driver).send_keys_to_element(
-        ctx.scraper.scrape_xpath(xpath)[0], *text
-    ).perform()
+    ActionChains(ctx.scraper.driver)\
+        .send_keys_to_element(ctx.scraper.scrape_xpath(xpath)[0], *text, Keys.ENTER)\
+        .perform()
 
 
 @scrape_action("scroll_to_bottom")

--- a/backend/app/scraping/actions/scrape_actions.py
+++ b/backend/app/scraping/actions/scrape_actions.py
@@ -61,9 +61,9 @@ def click(ctx: ScrapingContext, xpath: str, must_exist: bool = True):
 @scrape_action("type")
 def type(ctx: ScrapingContext, xpath: str, text: str):
     # TODO: Delay in between keystrokes
-    ActionChains(ctx.scraper.driver)\
-        .send_keys_to_element(ctx.scraper.scrape_xpath(xpath)[0], *text, Keys.ENTER)\
-        .perform()
+    ActionChains(ctx.scraper.driver).send_keys_to_element(
+        ctx.scraper.scrape_xpath(xpath)[0], *text, Keys.ENTER
+    ).perform()
 
 
 @scrape_action("scroll_to_bottom")
@@ -122,13 +122,15 @@ def scrape_property(ctx: ScrapingContext, prop: ScrapePropertyModel):
         # See https://stackoverflow.com/a/74250413/11827673
         # I don't really know what this pandas code is doing
         # But hey, it works!
-        ctx.data = pd.concat([
-            ctx.data.drop(columns=prop.name),
-            pd.concat([
-                previous_data,
-                new_data
-            ], ignore_index=True).to_frame(prop.name)
-        ], axis=1)
+        ctx.data = pd.concat(
+            [
+                ctx.data.drop(columns=prop.name),
+                pd.concat([previous_data, new_data], ignore_index=True).to_frame(
+                    prop.name
+                ),
+            ],
+            axis=1,
+        )
         ctx.scraping_progress[prop.name] += len(new_data)
     else:
         ctx.data[prop.name] = pd.Series(contents, dtype=prop.store_as)
@@ -144,10 +146,12 @@ def goto_next_page(ctx: ScrapingContext, next_page: str = None):
         if len(elements) > 0:
             valid = False
             for element, cursor in zip(elements, cursors):
-                if element.is_enabled() and \
-                   element.is_displayed() and \
-                   element.get_attribute("aria-disabled") != "true" and \
-                   cursor != "default":
+                if (
+                    element.is_enabled()
+                    and element.is_displayed()
+                    and element.get_attribute("aria-disabled") != "true"
+                    and cursor != "default"
+                ):
                     valid = True
             if valid:
                 click(ctx, next_page)
@@ -158,15 +162,16 @@ def goto_next_page(ctx: ScrapingContext, next_page: str = None):
         pass
     return False
 
+
 @scrape_action("scrape")
 def scrape(
-        ctx: ScrapingContext,
-        link: AnyUrl = None,
-        link_property: str = None,
-        prop: ScrapePropertyModel = None,
-        properties: List[ScrapePropertyModel] = None,
-        next_page: str = None,
-        scroll: bool = False
+    ctx: ScrapingContext,
+    link: AnyUrl = None,
+    link_property: str = None,
+    prop: ScrapePropertyModel = None,
+    properties: List[ScrapePropertyModel] = None,
+    next_page: str = None,
+    scroll: bool = False,
 ):
     if prop is not None and properties is not None:
         raise ValueError('Both "prop" and "properties" were specified!')
@@ -183,7 +188,14 @@ def scrape(
         num_links = len(links)
         for link in links:
             LOG.info(f"Scraping link {i}/{num_links} ({link})...")
-            scrape(ctx, link=link, prop=prop, properties=properties, next_page=next_page, scroll=scroll)
+            scrape(
+                ctx,
+                link=link,
+                prop=prop,
+                properties=properties,
+                next_page=next_page,
+                scroll=scroll,
+            )
             # Uncomment below to just scrape 3 links
             # TODO: Add a command-line argument to limit how many internships we scrape for testing
             # Need to coordinate with scrape_property or all of the info on the first page for the other internships

--- a/backend/app/scraping/actions/scrape_actions.py
+++ b/backend/app/scraping/actions/scrape_actions.py
@@ -188,8 +188,8 @@ def scrape(
             # TODO: Add a command-line argument to limit how many internships we scrape for testing
             # Need to coordinate with scrape_property or all of the info on the first page for the other internships
             # will be scraped
-            if i == 3:
-                return
+            # if i == 3:
+            #     return
             i += 1
         return
 

--- a/backend/app/scraping/actions/scrape_actions.py
+++ b/backend/app/scraping/actions/scrape_actions.py
@@ -6,7 +6,7 @@ from typing import Callable, List
 
 import pandas as pd
 from pydantic import AnyUrl
-from selenium.common import NoSuchElementException
+from selenium.common import NoSuchElementException, TimeoutException
 from selenium.webdriver import ActionChains
 
 from backend.app.utils import LOG
@@ -40,9 +40,15 @@ def sleep(ms: float):
 
 
 @scrape_action("click")
-def click(ctx: ScrapingContext, xpath: str):
+def click(ctx: ScrapingContext, xpath: str, must_exist: bool = True):
     for element in ctx.scraper.scrape_xpath(xpath):
-        ActionChains(ctx.scraper.driver).click(element).perform()
+        if must_exist:
+            ctx.scraper.js("arguments[0].click()", element)
+        else:
+            try:
+                ctx.scraper.js("arguments[0].click()", element)
+            except TimeoutException:
+                continue
 
 
 @scrape_action("type")

--- a/backend/app/scraping/actions/scrape_actions.py
+++ b/backend/app/scraping/actions/scrape_actions.py
@@ -40,7 +40,8 @@ def sleep(ms: float):
 
 @scrape_action("click")
 def click(ctx: ScrapingContext, xpath: str):
-    ActionChains(ctx.scraper.driver).click(ctx.scraper.scrape_xpath(xpath)[0]).perform()
+    for element in ctx.scraper.scrape_xpath(xpath):
+        ActionChains(ctx.scraper.driver).click(element).perform()
 
 
 @scrape_action("type")

--- a/backend/app/scraping/actions/scrape_actions.py
+++ b/backend/app/scraping/actions/scrape_actions.py
@@ -41,16 +41,21 @@ def sleep(ms: float):
 
 @scrape_action("click")
 def click(ctx: ScrapingContext, xpath: str, must_exist: bool = True):
-    for element in ctx.scraper.scrape_xpath(xpath):
+    elements = ctx.scraper.scrape_xpath(xpath)
+    i = 0
+    for element in elements:
+        i += 1
+        LOG.info(f"Clicking element {i}/{len(elements)}...")
         if must_exist:
             ctx.scraper.js("arguments[0].click()", element)
-            time.sleep(1)
+            time.sleep(0.25)
         else:
             try:
                 ctx.scraper.js("arguments[0].click()", element)
-                time.sleep(1)
+                time.sleep(0.25)
             except TimeoutException:
                 continue
+    time.sleep(1)
 
 
 @scrape_action("type")

--- a/backend/app/scraping/actions/scrape_actions.py
+++ b/backend/app/scraping/actions/scrape_actions.py
@@ -182,7 +182,9 @@ def scrape(
             scrape(ctx, link=link, prop=prop, properties=properties, next_page=next_page)
             # Uncomment below to just scrape 3 links
             # TODO: Add a command-line argument to limit how many internships we scrape for testing
-            # if i == 2:
+            # Need to coordinate with scrape_property or all of the info on the first page for the other internships
+            # will be scraped
+            # if i == 3:
             #     return
             i += 1
         return

--- a/backend/app/scraping/actions/scrape_actions.py
+++ b/backend/app/scraping/actions/scrape_actions.py
@@ -132,7 +132,7 @@ def goto_next_page(ctx: ScrapingContext, next_page: str = None):
         if len(elements) > 0:
             valid = False
             for element in elements:
-                if element.is_enabled() and element.get_attribute("aria-disabled") != "true":
+                if element.is_enabled() and element.is_displayed() and element.get_attribute("aria-disabled") != "true":
                     valid = True
             if valid:
                 click(ctx, next_page)

--- a/backend/app/scraping/actions/scrape_actions.py
+++ b/backend/app/scraping/actions/scrape_actions.py
@@ -79,7 +79,13 @@ def scroll_to_bottom(ctx: ScrapingContext):
 def scrape_property(ctx: ScrapingContext, prop: ScrapePropertyModel):
     if prop.unique and prop.name not in ctx.unique_properties:
         ctx.unique_properties.append(prop.name)
-    elements = ctx.scraper.scrape_xpath(prop.xpath)
+    try:
+        elements = ctx.scraper.scrape_xpath(prop.xpath)
+    except TimeoutException:
+        LOG.error(f"Unable to find {prop.name}! ({prop.xpath})")
+        LOG.error(f"Assuming 1 element wasn't found.")
+        ctx.scraping_progress[prop.name] += 1
+        return
     # Create column with found elements and add to DataFrame
     contents = []
     for element in elements:

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -263,8 +263,8 @@ def scrape(args: Namespace):
         for idx, entry in company_scrape_df.iterrows():
             # Uncomment below to just scrape Amazon
             # TODO: Add a command-line argument to select which company/companies to scrape
-            if entry["company"] != "HewlettPackardEnterprise":
-                continue
+            # if entry["company"] != "Amazon":
+            #     continue
             LOG.info(f"Scraping {entry['company']}...")
             scraper.scrape_company(entry["link"], entry)
         LOG.info("Done!")

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -81,7 +81,9 @@ class WebScraper:
 
     def scrape_xpath(self, xpath: str) -> list:
         return self.wait.until(
-            condition.presence_of_all_elements_located((By.XPATH, xpath))
+            condition.presence_of_all_elements_located(
+                (By.XPATH, xpath)
+            )
         )
 
     def commit_internships(self, ctx: ScrapingContext) -> bool:
@@ -132,7 +134,12 @@ class WebScraper:
                 LOG.error(f"Internship: {internship.to_dict()}")
                 LOG.error(errors)
                 success = False
-        crud.create_internships(ctx.db, *internships_to_add)
+        try:
+            crud.create_internships(ctx.db, *internships_to_add)
+            LOG.error("Saving to database succeeded!")
+        except Exception as e:
+            LOG.error("Saving to database FAILED!")
+            LOG.error(e)
         return success
 
     def scrape_company(self, link: str, config: pd.Series):

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 import pandas as pd
 import selenium.webdriver.support.expected_conditions as condition
 from pydantic import ValidationError
+from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
@@ -79,7 +80,7 @@ class WebScraper:
     def js(self, code: str, *args: Any) -> Any:
         return self.driver.execute_script(code, *args)
 
-    def scrape_xpath(self, xpath: str) -> list:
+    def scrape_xpath(self, xpath: str) -> list[WebElement]:
         return self.wait.until(
             condition.presence_of_all_elements_located(
                 (By.XPATH, xpath)
@@ -242,6 +243,10 @@ def scrape(args: Namespace):
             company_scrape_df["scrape"].notna()
         ]
         for idx, entry in company_scrape_df.iterrows():
+            # Uncomment below to just scrape Amazon
+            # TODO: Add a command-line argument to select which company/companies to scrape
+            if entry["company"] != "Amazon":
+                continue
             LOG.info(f"Scraping {entry['company']}...")
             scraper.scrape_company(entry["link"], entry)
         LOG.info("Done!")

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -74,11 +74,11 @@ class WebScraper:
                 delay_amount = self.crawl_delay - time_passed
                 LOG.info(f"Delaying for {delay_amount:.2f} seconds...")
                 time.sleep(delay_amount)
+        self.last_request_time = datetime.now()
         try:
             self.driver.get(link)
         except InvalidArgumentException as e:
             LOG.exception(f"Could not navigate to link: {link}", e)
-        self.last_request_time = datetime.now()
         self.wait.until(
             lambda d: d.execute_script("return document.readyState") == "complete"
         )

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -263,7 +263,7 @@ def scrape(args: Namespace):
         for idx, entry in company_scrape_df.iterrows():
             # Uncomment below to just scrape Amazon
             # TODO: Add a command-line argument to select which company/companies to scrape
-            if entry["company"] != "GeneralMotors":
+            if entry["company"] != "Google":
                 continue
             LOG.info(f"Scraping {entry['company']}...")
             scraper.scrape_company(entry["link"], entry)

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -263,7 +263,7 @@ def scrape(args: Namespace):
         for idx, entry in company_scrape_df.iterrows():
             # Uncomment below to just scrape Amazon
             # TODO: Add a command-line argument to select which company/companies to scrape
-            if entry["company"] != "Dell":
+            if entry["company"] != "GeneralElectric":
                 continue
             LOG.info(f"Scraping {entry['company']}...")
             scraper.scrape_company(entry["link"], entry)

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -263,7 +263,7 @@ def scrape(args: Namespace):
         for idx, entry in company_scrape_df.iterrows():
             # Uncomment below to just scrape Amazon
             # TODO: Add a command-line argument to select which company/companies to scrape
-            if entry["company"] != "GeneralElectric":
+            if entry["company"] != "GeneralMotors":
                 continue
             LOG.info(f"Scraping {entry['company']}...")
             scraper.scrape_company(entry["link"], entry)

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -263,7 +263,7 @@ def scrape(args: Namespace):
         for idx, entry in company_scrape_df.iterrows():
             # Uncomment below to just scrape Amazon
             # TODO: Add a command-line argument to select which company/companies to scrape
-            if entry["company"] != "Comcast":
+            if entry["company"] != "Dell":
                 continue
             LOG.info(f"Scraping {entry['company']}...")
             scraper.scrape_company(entry["link"], entry)

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -16,9 +16,9 @@ import requests
 import selenium.webdriver.support.expected_conditions as condition
 from pydantic import ValidationError
 from selenium.common import InvalidArgumentException
-from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support.wait import WebDriverWait
 from undetected_chromedriver import Chrome
 
@@ -88,9 +88,7 @@ class WebScraper:
 
     def scrape_xpath(self, xpath: str) -> list[WebElement]:
         return self.wait.until(
-            condition.presence_of_all_elements_located(
-                (By.XPATH, xpath)
-            )
+            condition.presence_of_all_elements_located((By.XPATH, xpath))
         )
 
     def scrape_css(self, xpath: str, property_value: str) -> list[dict]:
@@ -98,7 +96,7 @@ class WebScraper:
             self.js(
                 "return window.getComputedStyle(arguments[0]).getPropertyValue(arguments[1])",
                 element,
-                property_value
+                property_value,
             )
             for element in self.scrape_xpath(xpath)
         ]
@@ -173,20 +171,22 @@ class WebScraper:
         robots_txt_response = requests.get(
             f"{parsed_link.scheme if len(parsed_link.scheme) > 0 else 'http'}://{parsed_link.netloc}/robots.txt"
         )
-        robots_txt = None if robots_txt_response.status_code != 200 else robots_txt_response.text
+        robots_txt = (
+            None if robots_txt_response.status_code != 200 else robots_txt_response.text
+        )
         context = ScrapingContext(
             scraper=self,
             company=company_name,
             db=db,
             data=pd.DataFrame(),
-            robots_txt=robots_txt
+            robots_txt=robots_txt,
         )
         crawl_delay = None
         if robots_txt is not None:
             for line in context.robots_txt.splitlines():
                 line = line.strip()
                 while line.find("#") != -1:
-                    line = line[:line.find("#")]
+                    line = line[: line.find("#")]
                 if line.lower().startswith("crawl-delay:"):
                     new_crawl_delay = float(line[12:].strip())
                     if crawl_delay is None or new_crawl_delay < crawl_delay:

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -173,7 +173,7 @@ class WebScraper:
                 if crawl_delay is None or new_crawl_delay < crawl_delay:
                     crawl_delay = new_crawl_delay
         if crawl_delay is None:
-            crawl_delay = 0
+            crawl_delay = 1
         LOG.info(f"Crawl-delay: {crawl_delay}")
         self.goto(link)
         time.sleep(3)  # Make sure page is fully loaded

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -136,7 +136,7 @@ class WebScraper:
                 success = False
         try:
             crud.create_internships(ctx.db, *internships_to_add)
-            LOG.error("Saving to database succeeded!")
+            LOG.info("Saving to database succeeded!")
         except Exception as e:
             LOG.error("Saving to database FAILED!")
             LOG.error(e)

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -74,11 +74,11 @@ class WebScraper:
                 delay_amount = self.crawl_delay - time_passed
                 LOG.info(f"Delaying for {delay_amount:.2f} seconds...")
                 time.sleep(delay_amount)
-        self.last_request_time = datetime.now()
         try:
             self.driver.get(link)
         except InvalidArgumentException as e:
             LOG.exception(f"Could not navigate to link: {link}", e)
+        self.last_request_time = datetime.now()
         self.wait.until(
             lambda d: d.execute_script("return document.readyState") == "complete"
         )
@@ -191,6 +191,8 @@ class WebScraper:
                     new_crawl_delay = float(line[12:].strip())
                     if crawl_delay is None or new_crawl_delay < crawl_delay:
                         crawl_delay = new_crawl_delay
+        else:
+            LOG.info("No robots.txt was found!")
         if crawl_delay is None:
             crawl_delay = 1
         LOG.info(f"Crawl-delay: {crawl_delay}")

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -263,7 +263,7 @@ def scrape(args: Namespace):
         for idx, entry in company_scrape_df.iterrows():
             # Uncomment below to just scrape Amazon
             # TODO: Add a command-line argument to select which company/companies to scrape
-            if entry["company"] != "Cigna":
+            if entry["company"] != "Comcast":
                 continue
             LOG.info(f"Scraping {entry['company']}...")
             scraper.scrape_company(entry["link"], entry)

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -263,7 +263,7 @@ def scrape(args: Namespace):
         for idx, entry in company_scrape_df.iterrows():
             # Uncomment below to just scrape Amazon
             # TODO: Add a command-line argument to select which company/companies to scrape
-            if entry["company"] != "Google":
+            if entry["company"] != "HewlettPackardEnterprise":
                 continue
             LOG.info(f"Scraping {entry['company']}...")
             scraper.scrape_company(entry["link"], entry)

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -51,6 +51,7 @@ class WebScraper:
         if options is None:
             options = Options()
         options.headless = headless
+        options.add_argument("--start-maximized")
         # if auto_download:
         #     driver_manager = ChromeDriverManager()
         #     driver_exists = driver_manager.driver_cache.find_driver(driver_manager.driver)
@@ -91,6 +92,16 @@ class WebScraper:
                 (By.XPATH, xpath)
             )
         )
+
+    def scrape_css(self, xpath: str, property_value: str) -> list[dict]:
+        return [
+            self.js(
+                "return window.getComputedStyle(arguments[0]).getPropertyValue(arguments[1])",
+                element,
+                property_value
+            )
+            for element in self.scrape_xpath(xpath)
+        ]
 
     def commit_internships(self, ctx: ScrapingContext) -> bool:
         if not self.save_internships:
@@ -252,7 +263,7 @@ def scrape(args: Namespace):
         for idx, entry in company_scrape_df.iterrows():
             # Uncomment below to just scrape Amazon
             # TODO: Add a command-line argument to select which company/companies to scrape
-            if entry["company"] != "Boeing":
+            if entry["company"] != "Cigna":
                 continue
             LOG.info(f"Scraping {entry['company']}...")
             scraper.scrape_company(entry["link"], entry)

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -252,7 +252,7 @@ def scrape(args: Namespace):
         for idx, entry in company_scrape_df.iterrows():
             # Uncomment below to just scrape Amazon
             # TODO: Add a command-line argument to select which company/companies to scrape
-            if entry["company"] != "Amazon":
+            if entry["company"] != "Boeing":
                 continue
             LOG.info(f"Scraping {entry['company']}...")
             scraper.scrape_company(entry["link"], entry)

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -309,7 +309,63 @@
   {
     "company": "Cigna",
     "link": "https://jobs.cigna.com/us/en/search-results?keywords=Intern",
-    "scrape": null
+    "scrape": [
+      {
+        "action": "scrape",
+        "next_page": "//a[contains(@class,'next-btn')]",
+        "properties": [
+          {
+            "name": "title",
+            "xpath": "//div[@class='job-title']"
+          },
+          {
+            "name": "link",
+            "xpath": "//a[@ph-tevent='job_click']",
+            "html_property": "href",
+            "unique": true
+          },
+          {
+            "name": "category",
+            "xpath": "//span[contains(@class,'category')]",
+            "regex": {
+              "pattern": "(Category\\n)(.*)",
+              "group": 2
+            }
+          },
+          {
+            "name": "post_date",
+            "xpath": "//span[@class='job-postdate']",
+            "regex": {
+              "pattern": "(Posted Date\\n)(.*)",
+              "group": 2
+            }
+          }
+        ]
+      },
+      {
+        "action": "scrape",
+        "link_property": "link",
+        "properties": [
+          {
+            "name": "job_id",
+            "xpath": "//span[contains(@class,'jobId')]",
+            "regex": {
+              "pattern": "(Job Id\\n)(.*)",
+              "group": 2
+            }
+          },
+          {
+            "name": "apply_link",
+            "xpath": "(//a[@ph-tevent='apply_click'])[1]",
+            "html_property": "href"
+          },
+          {
+            "name": "description",
+            "xpath": "//section[@class='job-description']"
+          }
+        ]
+      }
+    ]
   },
   {
     "company": "Comcast",

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -426,8 +426,55 @@
   },
   {
     "company": "Dell",
-    "link": "https://jobs.dell.com/search-jobs",
-    "scrape": null
+    "link": "https://jobs.dell.com/category/internship-jobs/375/24213/1",
+    "scrape": [
+      {
+        "action": "click",
+        "xpath": "//a[@class='pagination-show-all']"
+      },
+      {
+        "action": "scrape",
+        "properties": [
+          {
+            "name": "link",
+            "xpath": "//section[@id='search-results-list']//a",
+            "html_property": "href",
+            "unique": true
+          },
+          {
+            "name": "title",
+            "xpath": "//section[@id='search-results-list']//a/h2"
+          },
+          {
+            "name": "location",
+            "xpath": "//span[@class='job-location-search']"
+          }
+        ]
+      },
+      {
+        "action": "scrape",
+        "link_property": "link",
+        "properties": [
+          {
+            "name": "apply_link",
+            "xpath": "(//a[contains(@class,'job-apply')])[1]",
+            "html_property": "href"
+          },
+          {
+            "name": "description",
+            "xpath": "//div[@class='ats-description']"
+          },
+          {
+            "name": "job_id",
+            "xpath": "//div[@class='ats-description']/following-sibling::p",
+            "regex": {
+              "pattern": "(Job ID:\\s)(.*)",
+              "group": 2
+            }
+          }
+        ]
+      }
+    ]
   },
   {
     "company": "Ecolab",

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -181,7 +181,60 @@
   {
     "company": "Apple",
     "link": "https://jobs.apple.com/en-us/search?team=Internships-STDNT-INTRN",
-    "scrape": null
+    "scrape": [
+      {
+        "action": "scrape",
+        "next_page": "//li[@class='pagination__next']//a",
+        "properties": [
+          {
+            "name": "title",
+            "xpath": "//a[contains(@id,'jotTitle')]"
+          },
+          {
+            "name": "link",
+            "xpath": "//a[contains(@id,'jotTitle')]",
+            "html_property": "href",
+            "unique": true
+          },
+          {
+            "name": "post_date",
+            "xpath": "//span[contains(@id,'postedDate')]"
+          }
+        ]
+      },
+      {
+        "action": "scrape",
+        "link_property": "link",
+        "properties": [
+          {
+            "name": "category",
+            "xpath": "//div[@id='job-team-name']"
+          },
+          {
+            "name": "apply_link",
+            "xpath": "(//div[@id='job-details-actions']/a)[1]",
+            "html_property": "href"
+          },
+          {
+            "name": "location",
+            "xpath": "//div[@itemprop='address']"
+          },
+          {
+            "name": "job_id",
+            "xpath": "//strong[@id='jobNumber']"
+          },
+          {
+            "name": "description",
+            "xpath": "//div[@itemprop='description']",
+            "regex": {
+              "pattern": "(Role Number:\\d*\\n)([\\s\\S]*)",
+              "group": 2,
+              "multiline": true
+            }
+          }
+        ]
+      }
+    ]
   },
   {
     "company": "Boeing",

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -239,7 +239,72 @@
   {
     "company": "Boeing",
     "link": "https://jobs.boeing.com/category/internship-jobs/185/9287/1",
-    "scrape": null
+    "scrape": [
+      {
+        "action": "click",
+        "xpath": "//a[@class='pagination-show-all']"
+      },
+      {
+        "action": "scrape",
+        "properties": [
+          {
+            "name": "title",
+            "xpath": "//ul[contains(@class,'sr-featured-jobs')]/li//a//h3"
+          },
+          {
+            "name": "link",
+            "xpath": "//ul[contains(@class,'sr-featured-jobs')]/li//a[contains(@class,'featured-job-')]",
+            "html_property": "href",
+            "unique": true
+          },
+          {
+            "name": "post_date",
+            "xpath": "//ul[contains(@class,'sr-featured-jobs')]/li//a//span[contains(@class,'job-date-posted')]"
+          },
+          {
+            "name": "title",
+            "xpath": "//ul[contains(@class,'sr-main-jobs')]/li//a//h3"
+          },
+          {
+            "name": "link",
+            "xpath": "//ul[contains(@class,'sr-main-jobs')]/li//a",
+            "html_property": "href",
+            "unique": true
+          },
+          {
+            "name": "post_date",
+            "xpath": "//ul[contains(@class,'sr-main-jobs')]/li//a//span[contains(@class,'job-date-posted')]"
+          }
+        ]
+      },
+      {
+        "action": "scrape",
+        "link_property": "link",
+        "properties": [
+          {
+            "name": "location",
+            "xpath": "//span[@class='job-location']"
+          },
+          {
+            "name": "apply_link",
+            "xpath": "(//a[contains(@class,'job-apply')])[1]",
+            "html_property": "href"
+          },
+          {
+            "name": "job_id",
+            "xpath": "//span[contains(@class,'job-id')]",
+            "regex": {
+              "pattern": "(Job ID )(.*)",
+              "group": 2
+            }
+          },
+          {
+            "name": "description",
+            "xpath": "//div[contains(@class,'job-description-wrap')]"
+          }
+        ]
+      }
+    ]
   },
   {
     "company": "Cigna",

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -693,8 +693,61 @@
   },
   {
     "company": "HewlettPackardEnterprise",
-    "link": "https://careers.hpe.com/us/en/search-results",
-    "scrape": null
+    "link": "https://careers.hpe.com/us/en/search-results?keywords=intern",
+    "scrape": [
+      {
+        "action": "scrape",
+        "properties": [
+          {
+            "name": "title",
+            "xpath": "//li[@class='jobs-list-item']//a"
+          },
+          {
+            "name": "link",
+            "xpath": "//li[@class='jobs-list-item']//a",
+            "html_property": "href",
+            "unique": true
+          },
+          {
+            "name": "post_date",
+            "xpath": "//li[@class='jobs-list-item']//a",
+            "html_property": "data-ph-at-job-post-date-text"
+          },
+          {
+            "name": "category",
+            "xpath": "//li[@class='jobs-list-item']//p[@class='job-info']/span[3]",
+            "regex": {
+              "pattern": "(Category\\n)(.*)",
+              "group": 2
+            }
+          },
+          {
+            "name": "job_id",
+            "xpath": "//li[@class='jobs-list-item']//p[@class='job-info']/span[5]",
+            "regex": {
+              "pattern": "(Job Id\\n)(.*)",
+              "group": 2
+            }
+          }
+        ]
+      },
+      {
+        "action": "scrape",
+        "link_property": "link",
+        "scroll": true,
+        "properties": [
+          {
+            "name": "apply_link",
+            "xpath": "//div[@class='job-header-actions']/a",
+            "html_property": "href"
+          },
+          {
+            "name": "description",
+            "xpath": "//div[@class='job-description']/div[@data-ph-at-id='jobdescription-text']"
+          }
+        ]
+      }
+    ]
   },
   {
     "company": "HomeDepot",

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -531,13 +531,66 @@
   },
   {
     "company": "ExxonMobil",
-    "link": "https://jobs.exxonmobil.com/search/?q=&locationsearch=&optionsFacetsDD_department=&optionsFacetsDD_shifttype=Intern%2Fco-op%2Fapprentice",
+    "link": "https://jobs.exxonmobil.com/search/?optionsFacetsDD_shifttype=Intern%2Fco-op%2Fapprentice",
     "scrape": null
   },
   {
     "company": "GeneralElectric",
     "link": "https://jobs.gecareers.com/global/en/search-results",
-    "scrape": null
+    "scrape": [
+      {
+        "action": "click",
+        "xpath": "//button[@id='ExperienceLevelAccordion']"
+      },
+      {
+        "action": "click",
+        "xpath": "//input[starts-with(@aria-label,'Co-op/Intern')]"
+      },
+      {
+        "action": "scrape",
+        "next_page": "//a[@aria-label='View next page']",
+        "scroll": true,
+        "properties": [
+          {
+            "name": "title",
+            "xpath": "//li[@class='jobs-list-item']//a"
+          },
+          {
+            "name": "link",
+            "xpath": "//li[@class='jobs-list-item']//a",
+            "html_property": "href",
+            "unique": true
+          },
+          {
+            "name": "category",
+            "xpath": "//li[@class='jobs-list-item']//span[contains(@class,'category')]"
+          },
+          {
+            "name": "post_date",
+            "xpath": "//li[@class='jobs-list-item']//span[@class='job-postdate']"
+          },
+          {
+            "name": "job_id",
+            "xpath": "//li[@class='jobs-list-item']//span[contains(@class,'jobId')]"
+          }
+        ]
+      },
+      {
+        "action": "scrape",
+        "link_property": "link",
+        "properties": [
+          {
+            "name": "apply_link",
+            "xpath": "(//a[@title='Apply Now'])[1]",
+            "html_property": "href"
+          },
+          {
+            "name": "description",
+            "xpath": "//div[@class='jd-info']"
+          }
+        ]
+      }
+    ]
   },
   {
     "company": "GeneralMotors",

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -416,7 +416,7 @@
             "name": "description",
             "xpath": "//div[@id='section-job-description']",
             "regex": {
-              "pattern": "(Job Summary:\n\n)([\\s\\S]*)",
+              "pattern": "(Job Summary:\\n\\n)([\\s\\S]*)",
               "multiline": true
             }
           }
@@ -521,7 +521,7 @@
             "name": "description",
             "xpath": "//div[@id='gtm-jobdetail-desc']//div[contains(@class,'panel-default')]",
             "regex": {
-              "pattern": "(Job Description\n\n)([\\s\\S]*)",
+              "pattern": "(Job Description\\n\\n)([\\s\\S]*)",
               "multiline": true
             }
           }
@@ -594,8 +594,61 @@
   },
   {
     "company": "GeneralMotors",
-    "link": "https://search-careers.gm.com/jobs/?search=&department=Students+%26+Recent+Graduates",
-    "scrape": null
+    "link": "https://search-careers.gm.com/en/jobs/?search=&team=Students+%26+Recent+Graduates",
+    "scrape": [
+      {
+        "action": "scrape",
+        "next_page": "//li[contains(@class,'next') and contains(@class,'page-item')]/a",
+        "properties": [
+          {
+            "name": "title",
+            "xpath": "//div[@id='js-job-search-results']//h2[@class='card-title']/a"
+          },
+          {
+            "name": "link",
+            "xpath": "//div[@id='js-job-search-results']//h2[@class='card-title']/a",
+            "html_property": "href",
+            "unique": true
+          },
+          {
+            "name": "job_id",
+            "xpath": "//div[@id='js-job-search-results']//div[contains(@class,'js-job')]",
+            "html_property": "data-id"
+          },
+          {
+            "name": "location",
+            "xpath": "//div[@id='js-job-search-results']//ul[contains(@class,'job-meta')]/li[2]"
+          }
+        ]
+      },
+      {
+        "action": "scrape",
+        "link_property": "link",
+        "properties": [
+          {
+            "name": "post_date",
+            "xpath": "//ul[contains(@class,'job-meta')]/li[3]",
+            "regex": {
+              "pattern": "(Posted\\n)(.*)",
+              "group": 2
+            }
+          },
+          {
+            "name": "apply_link",
+            "xpath": "//a[@id='js-apply-external']",
+            "html_property": "href"
+          },
+          {
+            "name": "description",
+            "xpath": "//article[@class='cms-content']",
+            "regex": {
+              "pattern": "(Description\\n\\n)([\\s\\S]*)",
+              "group": 2
+            }
+          }
+        ]
+      }
+    ]
   },
   {
     "company": "Google",

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -67,7 +67,57 @@
   {
     "company": "Allstate",
     "link": "https://www.allstate.jobs/job-search-results/?level[]=Intern",
-    "scrape": null
+    "scrape": [
+      {
+        "action": "scrape",
+        "properties": [
+          {
+            "name": "title",
+            "xpath": "//div[@class='jobTitle']"
+          },
+          {
+            "name": "link",
+            "xpath": "//div[@class='jobTitle']/a",
+            "html_property": "href"
+          },
+          {
+            "name": "category",
+            "xpath": "//div[@class='jobCategory']"
+          },
+          {
+            "name": "location",
+            "xpath": "//div[contains(@class,'joblist-location')]"
+          },
+          {
+            "name": "post_date",
+            "xpath": "//div[contains(@class,'joblist-posdate')]"
+          }
+        ]
+      },
+      {
+        "action": "scrape",
+        "link_property": "link",
+        "properties": [
+          {
+            "name": "job_id",
+            "xpath": "//span[@id='gtm-jobdetail-id']"
+          },
+          {
+            "name": "apply_link",
+            "xpath": "//a[contains(@class,'apply-btn')]",
+            "html_property": "href"
+          },
+          {
+            "name": "description",
+            "xpath": "//div[@id='gtm-jobdetail-desc']",
+            "regex": {
+              "pattern": "[\\s\\S]+(?=\\n\\nGood Work. Good Life. Good Hands)",
+              "multiline": true
+            }
+          }
+        ]
+      }
+    ]
   },
   {
     "company": "Amazon",

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -43,7 +43,7 @@
             "name": "description",
             "xpath": "//div[@class='ats-description']",
             "regex": {
-              "pattern": "(Job Overview\\n\\n)([\\s\\S]+)(\\n\\n\\n\\n\\nJob ID)",
+              "pattern": "(Job Overview\\n*)([\\s\\S]+)(\\n*Job ID)",
               "group": 2,
               "multiline": true
             }
@@ -305,7 +305,12 @@
           },
           {
             "name": "description",
-            "xpath": "//div[contains(@class,'job-description-wrap')]"
+            "xpath": "//div[contains(@class,'job-description-wrap')]",
+            "regex": {
+              "pattern": "(\\n*Job Description\\n*)([\\s\\S]+)(\\n*)",
+              "group": 2,
+              "multiline": true
+            }
           }
         ]
       }
@@ -530,7 +535,8 @@
             "name": "description",
             "xpath": "//div[@id='gtm-jobdetail-desc']//div[contains(@class,'panel-default')]",
             "regex": {
-              "pattern": "(Job Description\\n\\n)([\\s\\S]*)",
+              "pattern": "(Job Description\\n*)([\\s\\S]*)",
+              "group": 2,
               "multiline": true
             }
           }
@@ -706,6 +712,7 @@
     "scrape": [
       {
         "action": "scrape",
+        "next_page": "//a[contains(@class,'next-btn')]",
         "properties": [
           {
             "name": "title",

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -78,7 +78,8 @@
           {
             "name": "link",
             "xpath": "//div[@class='jobTitle']/a",
-            "html_property": "href"
+            "html_property": "href",
+            "unique": true
           },
           {
             "name": "category",
@@ -122,7 +123,60 @@
   {
     "company": "Amazon",
     "link": "https://www.amazon.jobs/en/teams/internships-for-students?offset=0&result_limit=10&sort=relevant&country%5B%5D=USA&distanceType=Mi&radius=24km&latitude=&longitude=&loc_group_id=&loc_query=&base_query=&city=&country=&region=&county=&query_options=&",
-    "scrape": null
+    "scrape": [
+      {
+        "action": "scrape",
+        "next_page": "//div[@class='pagination-control']/button[@aria-label='Next page']",
+        "properties": [
+          {
+            "name": "title",
+            "xpath": "//h3[@class='job-title']"
+          },
+          {
+            "name": "link",
+            "xpath": "//a[@class='job-link']",
+            "html_property": "href",
+            "unique": true
+          },
+          {
+            "name": "location",
+            "xpath": "//p[@class='location-and-id']",
+            "regex": {
+              "pattern": "[\\s\\S]+(?= \\| Job ID: )"
+            }
+          },
+          {
+            "name": "job_id",
+            "xpath": "//p[@class='location-and-id']",
+            "regex": {
+              "pattern": "(?<=\\| Job ID: )[\\s\\S]+"
+            }
+          },
+          {
+            "name": "post_date",
+            "xpath": "//h2[@class='posting-date']",
+            "regex": {
+              "pattern": "(?<=Posted )[\\s\\S]+"
+            }
+          }
+        ]
+      },
+      {
+        "action": "scrape",
+        "link_property": "link",
+        "properties": [
+          {
+            "name": "description",
+            "xpath": "//div[@id='job-detail-body']//div[@class='content']"
+          },
+          {
+            "name": "apply_link",
+            "xpath": "//a[@id='apply-button']",
+            "html_property": "href"
+          }
+        ]
+      }
+    ]
   },
   {
     "company": "Apple",

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -652,8 +652,44 @@
   },
   {
     "company": "Google",
-    "link": "https://careers.google.com/jobs/results/",
-    "scrape": null
+    "link": "https://careers.google.com/jobs/results/?employment_type=INTERN",
+    "scrape": [
+      {
+        "action": "scrape",
+        "next_page": "//a[@data-gtm-ref='search-results-next-click']",
+        "properties": [
+          {
+            "name": "title",
+            "xpath": "//a[@class='gc-card']//h2[contains(@class,'gc-card__title')]"
+          },
+          {
+            "name": "link",
+            "xpath": "//a[@class='gc-card']",
+            "html_property": "href",
+            "unique": true
+          }
+        ]
+      },
+      {
+        "action": "scrape",
+        "link_property": "link",
+        "properties": [
+          {
+            "name": "apply_link",
+            "xpath": "//div[contains(@class,'gc-job-detail__meta')]/a",
+            "html_property": "href"
+          },
+          {
+            "name": "description",
+            "xpath": "//div[contains(@class,'gc-card__content')]"
+          },
+          {
+            "name": "post_date",
+            "xpath": "//span[@itemprop='datePosted']"
+          }
+        ]
+      }
+    ]
   },
   {
     "company": "HewlettPackardEnterprise",

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -843,7 +843,7 @@
             "xpath": "//tbody/tr[@class='tds-table-row']/td[1]",
             "regex": {
               "pattern": "\\d{4}",
-              "default": null
+              "default": ""
             }
           },
           {
@@ -852,7 +852,7 @@
             "regex": {
               "pattern": "summer|spring|fall|winter",
               "ignore_case": true,
-              "default": null
+              "default": ""
             }
           },
           {

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -842,7 +842,8 @@
             "name": "year",
             "xpath": "//tbody/tr[@class='tds-table-row']/td[1]",
             "regex": {
-              "pattern": "\\d{4}"
+              "pattern": "\\d{4}",
+              "default": null
             }
           },
           {
@@ -850,7 +851,8 @@
             "xpath": "//tbody/tr[@class='tds-table-row']/td[1]",
             "regex": {
               "pattern": "summer|spring|fall|winter",
-              "ignore_case": true
+              "ignore_case": true,
+              "default": null
             }
           },
           {

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -43,17 +43,26 @@
             "name": "description",
             "xpath": "//div[@class='ats-description']",
             "regex": {
-              "pattern": "[\\s\\S]+(?=\\n\\n\\n\\n\\nJob ID)",
+              "pattern": "(Job Overview\\n\\n)([\\s\\S]+)(\\n\\n\\n\\n\\nJob ID)",
+              "group": 2,
               "multiline": true
             }
           },
           {
             "name": "job_id",
-            "xpath": "//span[contains(@class,'job-id')]"
+            "xpath": "//span[contains(@class,'job-id')]",
+            "regex": {
+              "pattern": "(Job ID )(.*)",
+              "group": 2
+            }
           },
           {
             "name": "post_date",
-            "xpath": "//span[contains(@class,'job-date')]"
+            "xpath": "//span[contains(@class,'job-date')]",
+            "regex": {
+              "pattern": "(Date posted )(.*)",
+              "group": 2
+            }
           },
           {
             "name": "apply_link",

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -1,8 +1,68 @@
 [
   {
     "company": "AT&T",
-    "link": "https://www.att.jobs/students",
-    "scrape": null
+    "link": "https://www.att.jobs/search-jobs",
+    "scrape": [
+      {
+        "action": "click",
+        "xpath": "//button[@id='category-toggle']"
+      },
+      {
+        "action": "click",
+        "xpath": "//input[@data-display='Internships']"
+      },
+      {
+        "action": "click",
+        "xpath": "//a[@class='pagination-show-all']",
+        "must_exist": false
+      },
+      {
+        "action": "scrape",
+        "properties": [
+          {
+            "name": "title",
+            "xpath": "//section[@id='search-results-list']//li//h2"
+          },
+          {
+            "name": "location",
+            "xpath": "//section[@id='search-results-list']//li//span[@class='job-location']"
+          },
+          {
+            "name": "link",
+            "xpath": "//section[@id='search-results-list']//li/a",
+            "html_property": "href",
+            "unique": true
+          }
+        ]
+      },
+      {
+        "action": "scrape",
+        "link_property": "link",
+        "properties": [
+          {
+            "name": "description",
+            "xpath": "//div[@class='ats-description']",
+            "regex": {
+              "pattern": "[\\s\\S]+(?=\\n\\n\\n\\n\\nJob ID)",
+              "multiline": true
+            }
+          },
+          {
+            "name": "job_id",
+            "xpath": "//span[contains(@class,'job-id')]"
+          },
+          {
+            "name": "post_date",
+            "xpath": "//span[contains(@class,'job-date')]"
+          },
+          {
+            "name": "apply_link",
+            "xpath": "//div[@id='anchor-navigation']//a[@data-selector-name='job-apply-link']",
+            "html_property": "href"
+          }
+        ]
+      }
+    ]
   },
   {
     "company": "Allstate",
@@ -182,7 +242,7 @@
             "xpath": "//div[@class='careers-width-constraint']/div/div[2]"
           },
           {
-            "name": "req_id",
+            "name": "job_id",
             "xpath": "//tbody/tr[@class='tds-table-row'][3]/td[1]"
           },
           {

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -110,11 +110,7 @@
           },
           {
             "name": "description",
-            "xpath": "//div[@id='gtm-jobdetail-desc']",
-            "regex": {
-              "pattern": "[\\s\\S]+(?=\\n\\nGood Work. Good Life. Good Hands)",
-              "multiline": true
-            }
+            "xpath": "//div[@id='gtm-jobdetail-desc']"
           }
         ]
       }
@@ -418,7 +414,11 @@
           },
           {
             "name": "description",
-            "xpath": "//div[@id='section-job-description']"
+            "xpath": "//div[@id='section-job-description']",
+            "regex": {
+              "pattern": "(Job Summary:\n\n)([\\s\\S]*)",
+              "multiline": true
+            }
           }
         ]
       }
@@ -478,8 +478,56 @@
   },
   {
     "company": "Ecolab",
-    "link": "https://jobs.ecolab.com/job-search-results/?keyword=intern",
-    "scrape": null
+    "link": "https://jobs.ecolab.com/job-search-results/?category[]=Internship",
+    "scrape": [
+      {
+        "action": "scrape",
+        "next_page": "//li[@class='pagination-li']/a[text()='>']",
+        "properties": [
+          {
+            "name": "title",
+            "xpath": "//div[@class='jobTitle']"
+          },
+          {
+            "name": "link",
+            "xpath": "//div[@class='jobTitle']/a",
+            "html_property": "href",
+            "unique": true
+          },
+          {
+            "name": "location",
+            "xpath": "//li[contains(@class,'city_state')]"
+          },
+          {
+            "name": "post_date",
+            "xpath": "//li[contains(@class,'open_date')]"
+          }
+        ]
+      },
+      {
+        "action": "scrape",
+        "link_property": "link",
+        "properties": [
+          {
+            "name": "job_id",
+            "xpath": "//span[@id='gtm-jobdetail-id']"
+          },
+          {
+            "name": "apply_link",
+            "xpath": "(//a[contains(@class,'apply-btn')])[1]",
+            "html_property": "href"
+          },
+          {
+            "name": "description",
+            "xpath": "//div[@id='gtm-jobdetail-desc']//div[contains(@class,'panel-default')]",
+            "regex": {
+              "pattern": "(Job Description\n\n)([\\s\\S]*)",
+              "multiline": true
+            }
+          }
+        ]
+      }
+    ]
   },
   {
     "company": "ExxonMobil",

--- a/data/scraping_config.json
+++ b/data/scraping_config.json
@@ -370,7 +370,59 @@
   {
     "company": "Comcast",
     "link": "https://jobs.comcast.com/university-relations/internships-coops#",
-    "scrape": null
+    "scrape": [
+      {
+        "action": "scrape",
+        "next_page": "//a[@aria-label='Next']",
+        "properties": [
+          {
+            "name": "title",
+            "loading_text": "Loading...",
+            "xpath": "//div[contains(@class,'table-item') and not(contains(@class,'hide'))]/a"
+          },
+          {
+            "name": "link",
+            "loading_text": "Loading...",
+            "xpath": "//div[contains(@class,'table-item') and not(contains(@class,'hide'))]/a",
+            "html_property": "href",
+            "unique": true
+          },
+          {
+            "name": "location",
+            "loading_text": "Loading...",
+            "xpath": "//div[contains(@class,'table-item') and not(contains(@class,'hide'))]//span[contains(@class,'item-location')]"
+          },
+          {
+            "name": "post_date",
+            "loading_text": "Loading...",
+            "xpath": "//div[contains(@class,'table-item') and not(contains(@class,'hide'))]//span[contains(@class,'item-date-posted')]"
+          }
+        ]
+      },
+      {
+        "action": "scrape",
+        "link_property": "link",
+        "properties": [
+          {
+            "name": "job_id",
+            "xpath": "//span[contains(@class,'req-id')]"
+          },
+          {
+            "name": "category",
+            "xpath": "//span[contains(@class,'job-detail-api-industrycode')]"
+          },
+          {
+            "name": "apply_link",
+            "xpath": "//a[contains(@class,'job-detail-api-apply_url')]",
+            "html_property": "href"
+          },
+          {
+            "name": "description",
+            "xpath": "//div[@id='section-job-description']"
+          }
+        ]
+      }
+    ]
   },
   {
     "company": "Dell",


### PR DESCRIPTION
# Improvements
- Closes #64
- Added scraping configs for **13 more websites**, roughly half of the entire scraping config
- Since some of these websites have 200-300 internships, the web scraper will likely collect the data on **more than 1000 internships** when it is run start to finish
- I have not run it start to finish, but I tested each company individually to make sure that the data is correct
- Updated the Internship model based on the data that I found on most websites

### To-Do Post Merge
- Create a command-line argument to pick which companies to scrape (since scraping everything will likely take 2-3 hours now)
  + For now, uncomment the testing code under the TODO in the `scrape` function `scraper.py` to choose which company/companies to scrape
- Create a command-line argument to limit the number of internships scraped off of each website
  + For now, uncomment the testing code under the TODO in the `scrape` function in `scrape_actions.py` to choose how many internship links are visited
- Right now, the code breaks if you modify the Internship models, we need to add a migration system, possibly based on [Alembic](https://alembic.sqlalchemy.org/en/latest/)
- Right now, if we scrape properties that are not in the Internship model, that data is lost because it cannot be put into the database
  + We should add a column for additional data that does not fit into the model
- Certain uncaught errors still crash the scraper, we need to make sure that we don't lose any data that we've scraped!