### PR TITLE
Add Search Functionality

### DIFF
--- a/backend/app/api/endpoints/internships.py
+++ b/backend/app/api/endpoints/internships.py
@@ -14,9 +14,11 @@ router = APIRouter()
 
 
 @router.get("/", response_model=List[InternshipSchema])
-async def get_all_internships(db: Session = Depends(get_db)):
+async def get_internships(
+    db: Session = Depends(get_db), skip: int = 0, limit: int = 100
+):
     """Returns all internships from the database"""
-    return crud.get_all_internships(db)
+    return crud.get_all_internships(db, skip=skip, limit=limit)
 
 
 @router.post("/", response_model=InternshipSchema)
@@ -32,6 +34,14 @@ async def create_internship(
         }
     )
     return crud.create_internship(db, db_internship)
+
+
+@router.post("/search", response_model=List[InternshipSchema])
+async def search_internships(
+    db: Session = Depends(get_db), q: str = None, skip: int = 0, limit: int = 100
+):
+    """Searches the database for internships"""
+    return crud.search_internships(db, q=q, skip=skip, limit=limit)
 
 
 # @router.delete("/")

--- a/backend/app/server.py
+++ b/backend/app/server.py
@@ -42,7 +42,8 @@ def run_server():
 
 def generate_client():
     sleep(1)
-    rmtree("./frontend/src/_generated", ignore_errors=True)
+    # The rmtree is not needed (openapi-typescript-codegen does it automatically)
+    # rmtree("./frontend/src/_generated", ignore_errors=True)
     system("cd frontend && npm run update-api-client")
 
 

--- a/frontend/src/_generated/api/services/InternshipsService.ts
+++ b/frontend/src/_generated/api/services/InternshipsService.ts
@@ -11,15 +11,27 @@ import { request as __request } from '../core/request';
 export class InternshipsService {
 
     /**
-     * Get All Internships
+     * Get Internships
      * Returns all internships from the database
+     * @param skip
+     * @param limit
      * @returns Internship Successful Response
      * @throws ApiError
      */
-    public static getAllInternships(): CancelablePromise<Array<Internship>> {
+    public static getInternships(
+skip?: number,
+limit: number = 100,
+): CancelablePromise<Array<Internship>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/internships/',
+            query: {
+                'skip': skip,
+                'limit': limit,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
         });
     }
 
@@ -38,6 +50,34 @@ requestBody: InternshipCreate,
             url: '/api/v1/internships/',
             body: requestBody,
             mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Search Internships
+     * Searches the database for internships
+     * @param q
+     * @param skip
+     * @param limit
+     * @returns Internship Successful Response
+     * @throws ApiError
+     */
+    public static searchInternships(
+q?: string,
+skip?: number,
+limit: number = 100,
+): CancelablePromise<Array<Internship>> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/internships/search',
+            query: {
+                'q': q,
+                'skip': skip,
+                'limit': limit,
+            },
             errors: {
                 422: `Validation Error`,
             },

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -2,9 +2,10 @@
 <app-toolbar></app-toolbar>
 
 <div class="content">
-    <app-sidebar></app-sidebar>
-    <app-internship-list *ngIf="internships" [internships]="internships" (internshipClicked)="onInternshipClicked($event)"></app-internship-list>
+    <app-sidebar (searchChanged)="doSearch($event)"></app-sidebar>
+    <mat-spinner *ngIf="loading" mode="indeterminate"></mat-spinner>
+    <app-internship-list *ngIf="!loading && internships" [internships]="internships" (internshipClicked)="onInternshipClicked($event)"></app-internship-list>
     <div style="height: 100%">
-        <app-internship-details *ngIf="selectedInternship" [internship]="selectedInternship"></app-internship-details>
+        <app-internship-details *ngIf="!loading && selectedInternship" [internship]="selectedInternship"></app-internship-details>
     </div>
 </div>

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -11,3 +11,8 @@
     grid-template-rows: 1fr;
     flex-grow: 1;
 }
+
+mat-spinner {
+  grid-column: 2 / -1;
+  margin: 5em auto;
+}

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import {Component, OnInit} from '@angular/core'
 import {Internship, InternshipsService} from "../_generated/api";
 import {InternshipClickedEvent} from "./internship-list/internship-list.component";
+import {MatSnackBar} from "@angular/material/snack-bar";
 
 @Component({
   selector: 'app-root',
@@ -10,14 +11,41 @@ import {InternshipClickedEvent} from "./internship-list/internship-list.componen
 export class AppComponent implements OnInit {
   internships: Internship[] = []
   selectedInternship!: Internship
+  loading: boolean = true
+  search: string = ""
 
-  async ngOnInit() {
-    this.internships = await InternshipsService.getAllInternships()
-    this.selectedInternship = this.internships[0]
+  constructor( private snackBar: MatSnackBar ) {
+  }
+
+  ngOnInit() {
+    this.updateInternships = this.updateInternships.bind(this)
+    InternshipsService.getInternships().then(this.updateInternships)
   }
 
   onInternshipClicked( event: InternshipClickedEvent ) {
     this.selectedInternship = event.internship
     window.scroll( { top: 0, left: 0, behavior: "smooth" } )
+  }
+
+  doSearch( search: string ) {
+    this.search = search
+    this.internships = []
+    this.loading = true
+    InternshipsService.searchInternships(this.search).then( internships => {
+      this.snackBar.open(
+        internships.length + ( internships.length === 100 ? " or more" : "" ) + " internships found",
+        undefined,
+        {
+        verticalPosition: "bottom",
+        duration: 2000
+      } )
+      this.updateInternships( internships )
+    })
+  }
+
+  updateInternships( internships: Internship[] ) {
+    this.internships = internships
+    this.selectedInternship = this.internships[0]
+    this.loading = false
   }
 }

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -20,6 +20,9 @@ import {SidebarComponent} from './sidebar/sidebar.component';
 import {InternshipListComponent} from './internship-list/internship-list.component';
 import {InternshipDetailsComponent} from './internship-details/internship-details.component';
 import {InternshipCardComponent} from './internship-card/internship-card.component';
+import {MatProgressSpinnerModule} from "@angular/material/progress-spinner";
+import {FormsModule, ReactiveFormsModule} from "@angular/forms";
+import {MatSnackBarModule} from "@angular/material/snack-bar";
 
 @NgModule({
   declarations: [
@@ -34,6 +37,8 @@ import {InternshipCardComponent} from './internship-card/internship-card.compone
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
+    FormsModule,
+    ReactiveFormsModule,
     MatToolbarModule,
     MatButtonModule,
     MatIconModule,
@@ -43,7 +48,9 @@ import {InternshipCardComponent} from './internship-card/internship-card.compone
     MatInputModule,
     MatSelectModule,
     MatDividerModule,
-    MatDialogModule
+    MatDialogModule,
+    MatProgressSpinnerModule,
+    MatSnackBarModule
   ],
   providers: [
     {

--- a/frontend/src/app/internship-card/internship-card.component.html
+++ b/frontend/src/app/internship-card/internship-card.component.html
@@ -10,13 +10,13 @@
     </mat-card-header>
     <mat-card-content>
         <div style="white-space: pre-wrap">{{
-          internship.description !== undefined && internship.description.length > 497
+          internship.description !== undefined && internship.description.length > 500
             ? internship.description.substring( 0, 497 ) + "..."
             : internship.description
           }}</div>
         <br/>
         <mat-chip-list>
-            <mat-chip color="accent" selected *ngFor="let n of [ 1, 2, 3, 4, 5, 6, 7, 8 ]">Tag {{n}}</mat-chip>
+            <mat-chip color="accent" selected *ngFor="let tag of tags">{{tag}}</mat-chip>
             <!-- TODO: Replace this with iteration over tags (once they're in the Internship model)-->
         </mat-chip-list>
     </mat-card-content>

--- a/frontend/src/app/internship-card/internship-card.component.scss
+++ b/frontend/src/app/internship-card/internship-card.component.scss
@@ -3,6 +3,8 @@
 .internship-card {
     margin: 2em;
     cursor: pointer;
+    transition: 150ms ease-in-out;
+    user-select: none;
     @include mat.elevation(1);
 
     div.icon {
@@ -15,6 +17,14 @@
 
     &:hover {
         @include mat.elevation(16);
+        transform: scale(1.025);
+        z-index: 999;
+    }
+
+    &:active {
+        transition: 80ms ease-in-out;
+        @include mat.elevation(1);
+        transform: scale(0.975);
         z-index: 999;
     }
 

--- a/frontend/src/app/internship-card/internship-card.component.ts
+++ b/frontend/src/app/internship-card/internship-card.component.ts
@@ -6,6 +6,18 @@ import {Internship} from "../../_generated/api";
   templateUrl: './internship-card.component.html',
   styleUrls: ['./internship-card.component.scss']
 })
-export class InternshipCardComponent {
-    @Input() internship!: Internship
+export class InternshipCardComponent implements OnInit {
+  @Input() internship!: Internship
+  tags: string[] = []
+
+  ngOnInit(): void {
+    let all_tags = (
+      "cloud electrical management sales big-data " +
+      "ui web-dev finance robotics research " +
+      "ai nlp design c++ python " +
+      "database statistics seo devops security " +
+      "java c# rust"
+    ).split(" ").sort(() => 0.5 - Math.random())
+    this.tags = all_tags.slice(0, Math.floor(Math.random() * 8) + 3)
+  }
 }

--- a/frontend/src/app/internship-details/internship-details.component.html
+++ b/frontend/src/app/internship-details/internship-details.component.html
@@ -1,4 +1,4 @@
-<mat-card class="internship-details">
+<mat-card class="internship-details" [@enterLeave]="internship">
     <mat-card-title-group>
         <mat-card-title>
             {{internship.title}}
@@ -6,16 +6,18 @@
         <mat-card-subtitle>
             {{internship.company}}
         </mat-card-subtitle>
-        <a
-          mat-flat-button
-          color="accent"
-          class="apply-now"
-          [href]="internship.apply_link"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-            <span>Apply Now!</span>&nbsp;&nbsp;&nbsp;&nbsp;<mat-icon matSuffix class="apply-now-icon">open_in_new</mat-icon>
-        </a>
+        <div>
+            <a
+              mat-flat-button
+              color="accent"
+              class="apply-now"
+              [href]="internship.link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+                <span>Apply Now!</span>&nbsp;&nbsp;&nbsp;&nbsp;<mat-icon matSuffix class="apply-now-icon">open_in_new</mat-icon>
+            </a>
+        </div>
     </mat-card-title-group>
     <mat-card-content style="white-space: pre-wrap">{{internship.description}}</mat-card-content>
 </mat-card>

--- a/frontend/src/app/internship-details/internship-details.component.ts
+++ b/frontend/src/app/internship-details/internship-details.component.ts
@@ -1,10 +1,26 @@
 import {Component, Input, OnInit} from '@angular/core';
 import {Internship} from "../../_generated/api";
+import {animate, style, transition, trigger} from "@angular/animations";
 
 @Component({
   selector: 'app-internship-details',
   templateUrl: './internship-details.component.html',
-  styleUrls: ['./internship-details.component.scss']
+  styleUrls: ['./internship-details.component.scss'],
+  animations: [
+    trigger('enterLeave', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'translateY(1em)' }),
+        animate('250ms', style({ opacity: 1, transform: 'translateY(0)' })),
+      ]),
+      transition(':leave', [
+        animate('100ms', style({ opacity: 0 }))
+      ]),
+      transition('* => *', [
+        style({ opacity: 0, transform: 'translateY(1em)' }),
+        animate('250ms', style({ opacity: 1, transform: 'translateY(0)' })),
+      ])
+    ])
+  ]
 })
 export class InternshipDetailsComponent {
   @Input() public internship!: Internship

--- a/frontend/src/app/internship-list/internship-list.component.html
+++ b/frontend/src/app/internship-list/internship-list.component.html
@@ -1,1 +1,3 @@
-<app-internship-card *ngFor="let internship of internships; let i = index" [internship]="internship" (click)="onInternshipClicked(i)"></app-internship-card>
+<div @enterLeave>
+  <app-internship-card *ngFor="let internship of internships; let i = index" [internship]="internship" (click)="onInternshipClicked(i)"></app-internship-card>
+</div>

--- a/frontend/src/app/internship-list/internship-list.component.ts
+++ b/frontend/src/app/internship-list/internship-list.component.ts
@@ -1,5 +1,6 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {Internship} from "../../_generated/api";
+import {animate, style, transition, trigger} from "@angular/animations";
 
 export type InternshipClickedEvent = {
   index: number
@@ -9,7 +10,22 @@ export type InternshipClickedEvent = {
 @Component({
   selector: 'app-internship-list',
   templateUrl: './internship-list.component.html',
-  styleUrls: ['./internship-list.component.scss']
+  styleUrls: ['./internship-list.component.scss'],
+  animations: [
+    trigger('enterLeave', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'translateY(1em)' }),
+        animate('250ms', style({ opacity: 1, transform: 'translateY(0)' })),
+      ]),
+      transition(':leave', [
+        animate('100ms', style({ opacity: 0 }))
+      ]),
+      transition('* => *', [
+        style({ opacity: 0, transform: 'translateY(1em)' }),
+        animate('250ms', style({ opacity: 1, transform: 'translateY(0)' })),
+      ])
+    ])
+  ]
 })
 export class InternshipListComponent {
   @Input() internships: Internship[] = []

--- a/frontend/src/app/sidebar/sidebar.component.html
+++ b/frontend/src/app/sidebar/sidebar.component.html
@@ -2,14 +2,14 @@
     <div class="sidebar">
         <h1>Search</h1>
         <mat-form-field>
-            <input matInput type="text">
+            <input matInput type="text" placeholder="Search Internships..." [formControl]="search">
             <button matSuffix mat-icon-button aria-label="Search">
                 <mat-icon>search</mat-icon>
             </button>
         </mat-form-field>
         <mat-form-field>
             <mat-label>Sort</mat-label>
-            <mat-select [(value)]="sort">
+            <mat-select [formControl]="sort">
                 <mat-option value="relevance">Relevance</mat-option>
                 <mat-option value="date">Date</mat-option>
                 <mat-option value="alpha">Alphabetical</mat-option>
@@ -19,14 +19,29 @@
         <h1>Filters</h1>
         <mat-form-field>
             <mat-label>Major</mat-label>
-            <mat-select [(value)]="major">
-                <mat-option value="cpsc">Computer Science & Engineering</mat-option>
+            <mat-select [formControl]="major">
+                <mat-option value="aero">Aerospace Engineering</mat-option>
+                <mat-option value="aren">Architectural Engineering</mat-option>
+                <mat-option value="baen">Biological & Agricultural Engineering</mat-option>
+                <mat-option value="bmen">Biomedical Engineering</mat-option>
+                <mat-option value="chen">Chemical Engineering</mat-option>
+                <mat-option value="cven">Civil & Environmental Engineering</mat-option>
+                <mat-option value="cpen">Computer Science & Engineering</mat-option>
+                <mat-option value="elen">Electrical & Computer Engineering</mat-option>
+                <mat-option value="eset">Electronic Systems Engineering Technology</mat-option>
+                <mat-option value="inen">Industrial & Systems Engineering</mat-option>
+                <mat-option value="msen">Materials Science & Engineering</mat-option>
+                <mat-option value="meen">Mechanical Engineering</mat-option>
+                <mat-option value="mxet">Multidisciplinary Engineering</mat-option>
+                <mat-option value="nuen">Nuclear Engineering</mat-option>
+                <mat-option value="ocen">Ocean Engineering</mat-option>
+                <mat-option value="pete">Petroleum Engineering</mat-option>
             </mat-select>
         </mat-form-field>
         <div style="display: flex; flex-direction: row; justify-content: space-between;">
             <mat-form-field style="width: 48%">
                 <mat-label>Season</mat-label>
-                <mat-select [(value)]="season">
+                <mat-select [formControl]="season">
                     <mat-option value="summer">Summer</mat-option>
                     <mat-option value="fall">Fall</mat-option>
                     <mat-option value="spring">Spring</mat-option>
@@ -35,7 +50,7 @@
             </mat-form-field>
             <mat-form-field style="width: 48%">
                 <mat-label>Year</mat-label>
-                <mat-select [(value)]="year">
+                <mat-select [formControl]="year">
                     <mat-option value="2022">2022</mat-option>
                     <mat-option value="2023">2023</mat-option>
                     <mat-option value="2024">2024</mat-option>

--- a/frontend/src/app/sidebar/sidebar.component.ts
+++ b/frontend/src/app/sidebar/sidebar.component.ts
@@ -1,13 +1,24 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, EventEmitter, OnInit, Output} from '@angular/core';
+import {FormControl} from "@angular/forms";
+import {debounceTime} from "rxjs";
 
 @Component({
   selector: 'app-sidebar',
   templateUrl: './sidebar.component.html',
   styleUrls: ['./sidebar.component.scss']
 })
-export class SidebarComponent {
-  sort = 'relevance';
-  major = 'cpsc';
-  season = 'summer';
-  year = '2022';
+export class SidebarComponent implements OnInit {
+  search = new FormControl('');
+  sort = new FormControl('alpha');
+  major = new FormControl('cpen');
+  season = new FormControl('summer');
+  year = new FormControl('2022');
+
+  @Output() searchChanged = new EventEmitter<string>();
+
+  ngOnInit(): void {
+    this.search.valueChanges
+      .pipe(debounceTime(500))
+      .subscribe(next => this.searchChanged.emit(next ?? ""))
+  }
 }


### PR DESCRIPTION
- Closes #82
- Added a `/internships/search` route that accepts text to search for
  + These terms are broken up on spaces and then the server looks for them in most fields of the internship model, including title, category, location, and job ID
  + After most fields are searched, the server searches within descriptions
  + There is no priority given to internships that mention more than one search term or that mention a term multiple times
- The search bar works!
  + The search bar calls the above endpoint and refreshes the internship list with the results
  + The API is automatically called after the user stops typing for half a second
  + The UI tells the user how many results were found so that they know that a search failed if it says zero
- Other UI improvements
  + Added randomized dummy tags for the internships in the internship list
  + Added subtle animations for when the internship list is loaded or the user selects an internship
  + Added a fun click animation for the internship list
  + Added a loading circle for when the UI is calling the API
  + Fixed the Apply Now button