### PR TITLE
Add pagination

### DIFF
--- a/frontend/src/_generated/api/services/InternshipsService.ts
+++ b/frontend/src/_generated/api/services/InternshipsService.ts
@@ -19,9 +19,9 @@ export class InternshipsService {
      * @throws ApiError
      */
     public static getInternships(
-skip?: number,
-limit: number = 100,
-): CancelablePromise<Array<Internship>> {
+        skip?: number,
+        limit: number = 100,
+    ): CancelablePromise<Array<Internship>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/internships/',
@@ -43,8 +43,8 @@ limit: number = 100,
      * @throws ApiError
      */
     public static createInternship(
-requestBody: InternshipCreate,
-): CancelablePromise<Internship> {
+        requestBody: InternshipCreate,
+    ): CancelablePromise<Internship> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/internships/',
@@ -66,10 +66,10 @@ requestBody: InternshipCreate,
      * @throws ApiError
      */
     public static searchInternships(
-q?: string,
-skip?: number,
-limit: number = 100,
-): CancelablePromise<Array<Internship>> {
+        q?: string,
+        skip?: number,
+        limit: number = 100,
+    ): CancelablePromise<Array<Internship>> {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/internships/search',

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,26 +1,22 @@
-<div class="columns is-gapless">
-  <div class="column">
-    <app-toolbar></app-toolbar>
-    <div class="columns is-gapless">
-      <div class="column is-one-fifth">
-        <app-sidebar (searchChanged)="doSearch($event)"></app-sidebar>
+<app-toolbar></app-toolbar>
+<div class="columns">
+  <div class="column is-one-fifth">
+    <app-sidebar (searchChanged)="doSearch($event)"></app-sidebar>
+  </div>
+  <div class="column is-two-fifths">
+    <div class="internship-list-content-container">
+      <mat-spinner *ngIf="loading" mode="indeterminate"></mat-spinner>
+      <div class="internship-list-items">
+        <app-internship-list *ngIf="!loading && internships" [internships]="internships" (internshipClicked)="onInternshipClicked($event)"></app-internship-list>
       </div>
-      <div class="column is-two-fifths">
-        <div class="internship-list-content-container">
-          <mat-spinner *ngIf="loading" mode="indeterminate"></mat-spinner>
-          <div class="internship-list-items">
-            <app-internship-list *ngIf="!loading && internships" [internships]="internships" (internshipClicked)="onInternshipClicked($event)"></app-internship-list>
-            <div class="internship-list-paginator" [hidden]="loading">
-              <mat-paginator #paginator [length]=1000 [pageSize]="10" [pageSizeOptions]="[10, 25, 50, 100]" (page)="pageChange($event)"></mat-paginator>
-            </div>
-          </div>
-        </div>
+      <div class="internship-list-paginator" [hidden]="loading">
+        <mat-paginator #paginator [showFirstLastButtons]="true" [length]=9999 [pageSize]="10" [pageSizeOptions]="[10, 25, 50, 100]" (page)="onPageChange($event)"></mat-paginator>
       </div>
-      <div class="column is-two-fifths">
-        <div class="internship-details-container">
-          <app-internship-details *ngIf="!loading && selectedInternship" [internship]="selectedInternship"></app-internship-details>
-        </div>
-      </div>
+    </div>
+  </div>
+  <div class="column is-two-fifths">
+    <div class="internship-details-container">
+      <app-internship-details *ngIf="!loading && selectedInternship" [internship]="selectedInternship"></app-internship-details>
     </div>
   </div>
 </div>

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,18 +1,26 @@
-
-<app-toolbar></app-toolbar>
-
-<div class="content">
-    <app-sidebar (searchChanged)="doSearch($event)"></app-sidebar>
-    <div class="internship-list-content-container">
-      <mat-spinner *ngIf="loading" mode="indeterminate"></mat-spinner>
-      <div class="internship-list-items">
-        <app-internship-list *ngIf="!loading && internships" [internships]="internships" (internshipClicked)="onInternshipClicked($event)"></app-internship-list>
+<div class="columns is-gapless">
+  <div class="column">
+    <app-toolbar></app-toolbar>
+    <div class="columns is-gapless">
+      <div class="column is-one-fifth">
+        <app-sidebar (searchChanged)="doSearch($event)"></app-sidebar>
       </div>
-      <div class="internship-list-paginator" [hidden]="loading">
-        <mat-paginator #paginator [length]=1000 [pageSize]="10" [pageSizeOptions]="[10, 25, 50, 100]" (page)="pageChange($event)"></mat-paginator>
+      <div class="column is-two-fifths">
+        <div class="internship-list-content-container">
+          <mat-spinner *ngIf="loading" mode="indeterminate"></mat-spinner>
+          <div class="internship-list-items">
+            <app-internship-list *ngIf="!loading && internships" [internships]="internships" (internshipClicked)="onInternshipClicked($event)"></app-internship-list>
+            <div class="internship-list-paginator" [hidden]="loading">
+              <mat-paginator #paginator [length]=1000 [pageSize]="10" [pageSizeOptions]="[10, 25, 50, 100]" (page)="pageChange($event)"></mat-paginator>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="column is-two-fifths">
+        <div class="internship-details-container">
+          <app-internship-details *ngIf="!loading && selectedInternship" [internship]="selectedInternship"></app-internship-details>
+        </div>
       </div>
     </div>
-    <div class="internship-details-container">
-        <app-internship-details *ngIf="!loading && selectedInternship" [internship]="selectedInternship"></app-internship-details>
-    </div>
+  </div>
 </div>

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -3,9 +3,16 @@
 
 <div class="content">
     <app-sidebar (searchChanged)="doSearch($event)"></app-sidebar>
-    <mat-spinner *ngIf="loading" mode="indeterminate"></mat-spinner>
-    <app-internship-list *ngIf="!loading && internships" [internships]="internships" (internshipClicked)="onInternshipClicked($event)"></app-internship-list>
-    <div style="height: 100%">
+    <div class="internship-list-content-container">
+      <mat-spinner *ngIf="loading" mode="indeterminate"></mat-spinner>
+      <div class="internship-list-items">
+        <app-internship-list *ngIf="!loading && internships" [internships]="internships" (internshipClicked)="onInternshipClicked($event)"></app-internship-list>
+      </div>
+      <div class="internship-list-paginator" [hidden]="loading">
+        <mat-paginator #paginator [length]=1000 [pageSize]="10" [pageSizeOptions]="[10, 25, 50, 100]" (page)="pageChange($event)"></mat-paginator>
+      </div>
+    </div>
+    <div class="internship-details-container">
         <app-internship-details *ngIf="!loading && selectedInternship" [internship]="selectedInternship"></app-internship-details>
     </div>
 </div>

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -5,13 +5,6 @@
     flex-direction: column;
 }
 
-.content {
-    display: grid;
-    grid-template-columns: minmax(225px, 0.5fr) minmax(225px, 0.75fr) minmax(300px, 1fr);
-    grid-template-rows: 1fr;
-    flex-grow: 1;
-}
-
 mat-spinner {
   grid-column: 2 / -1;
   margin: 5em auto;
@@ -28,12 +21,14 @@ mat-spinner {
         overflow-y: auto;
     }
 
-    .internship-list-paginator {
-      position: fixed;
-      bottom: 0px;
-    }
+  .internship-list-paginator {
+    position: fixed;
+    bottom: 0px;
+    z-index: 1000;
+  }
 }
 
 .internship-details-container {
+    height: 100vh;
     overflow-y: auto;
 }

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -16,3 +16,27 @@ mat-spinner {
   grid-column: 2 / -1;
   margin: 5em auto;
 }
+
+.internship-list-content-container {
+    height: 100%;
+
+    .internship-list-items {
+        height: 100vh;
+        position: relative;
+        overflow-y: auto;
+    }
+
+    .internship-list-paginator {
+      position: absolute;
+      bottom: 0;
+    }
+}
+
+.internship-details-container {
+    overflow-y: auto;
+}
+
+//.tasklist-tasks {
+//    display: block;
+//    overflow: hidden;
+//}

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -19,6 +19,8 @@ mat-spinner {
 
 .internship-list-content-container {
     height: 100%;
+    display: flex;
+    flex-direction: column;
 
     .internship-list-items {
         height: 100vh;
@@ -27,16 +29,11 @@ mat-spinner {
     }
 
     .internship-list-paginator {
-      position: absolute;
-      bottom: 0;
+      position: fixed;
+      bottom: 0px;
     }
 }
 
 .internship-details-container {
     overflow-y: auto;
 }
-
-//.tasklist-tasks {
-//    display: block;
-//    overflow: hidden;
-//}

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,14 +1,17 @@
-import {Component, OnInit} from '@angular/core'
+import {ChangeDetectorRef, Component, OnInit, AfterViewInit, ViewChild} from '@angular/core'
 import {Internship, InternshipsService} from "../_generated/api";
 import {InternshipClickedEvent} from "./internship-list/internship-list.component";
 import {MatSnackBar} from "@angular/material/snack-bar";
+import {MatPaginator, MatPaginatorIntl, PageEvent} from "@angular/material/paginator";
+import {MatTableDataSource} from "@angular/material/table";
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit, AfterViewInit {
+  @ViewChild('paginator', { static: false }) paginator: MatPaginator = new MatPaginator(new MatPaginatorIntl(), ChangeDetectorRef.prototype)
   internships: Internship[] = []
   selectedInternship!: Internship
   loading: boolean = true
@@ -19,7 +22,12 @@ export class AppComponent implements OnInit {
 
   ngOnInit() {
     this.updateInternships = this.updateInternships.bind(this)
-    InternshipsService.getInternships().then(this.updateInternships)
+  }
+
+  ngAfterViewInit() {
+    console.log(this.paginator.pageIndex)
+    console.log(this.paginator.pageSize)
+    InternshipsService.getInternships(this.paginator.pageIndex * this.paginator.pageSize, this.paginator.pageSize).then(this.updateInternships)
   }
 
   onInternshipClicked( event: InternshipClickedEvent ) {
@@ -47,5 +55,10 @@ export class AppComponent implements OnInit {
     this.internships = internships
     this.selectedInternship = this.internships[0]
     this.loading = false
+  }
+
+  pageChange(event: PageEvent) {
+    console.log(event);
+    InternshipsService.getInternships(event.pageIndex * event.pageSize, event.pageSize).then(this.updateInternships)
   }
 }

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,15 +1,4 @@
 import {NgModule} from '@angular/core';
-import {MatButtonModule} from "@angular/material/button"
-import {MatCardModule} from "@angular/material/card"
-import {MatChipsModule} from "@angular/material/chips"
-import {MatDialogModule} from "@angular/material/dialog"
-import {MatDividerModule} from "@angular/material/divider"
-import {MAT_FORM_FIELD_DEFAULT_OPTIONS} from "@angular/material/form-field"
-import {MatIconModule} from "@angular/material/icon"
-import {MatInputModule} from "@angular/material/input"
-import {MatSelectModule} from "@angular/material/select"
-import {MatSidenavModule} from "@angular/material/sidenav"
-import {MatToolbarModule} from "@angular/material/toolbar"
 import {BrowserModule} from '@angular/platform-browser';
 
 import {AppComponent} from './app.component';
@@ -20,37 +9,26 @@ import {SidebarComponent} from './sidebar/sidebar.component';
 import {InternshipListComponent} from './internship-list/internship-list.component';
 import {InternshipDetailsComponent} from './internship-details/internship-details.component';
 import {InternshipCardComponent} from './internship-card/internship-card.component';
-import {MatProgressSpinnerModule} from "@angular/material/progress-spinner";
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
-import {MatSnackBarModule} from "@angular/material/snack-bar";
+import {MaterialModule} from "./modules/material/material.module";
+import {MAT_FORM_FIELD_DEFAULT_OPTIONS} from "@angular/material/form-field";
 
 @NgModule({
   declarations: [
     AppComponent,
-    ProfileDialogComponent,
-    ToolbarComponent,
-    SidebarComponent,
-    InternshipListComponent,
+    InternshipCardComponent,
     InternshipDetailsComponent,
-    InternshipCardComponent
+    InternshipListComponent,
+    ProfileDialogComponent,
+    SidebarComponent,
+    ToolbarComponent,
   ],
   imports: [
-    BrowserModule,
     BrowserAnimationsModule,
+    BrowserModule,
     FormsModule,
+    MaterialModule,
     ReactiveFormsModule,
-    MatToolbarModule,
-    MatButtonModule,
-    MatIconModule,
-    MatSidenavModule,
-    MatCardModule,
-    MatChipsModule,
-    MatInputModule,
-    MatSelectModule,
-    MatDividerModule,
-    MatDialogModule,
-    MatProgressSpinnerModule,
-    MatSnackBarModule
   ],
   providers: [
     {

--- a/frontend/src/app/modules/material/material.module.ts
+++ b/frontend/src/app/modules/material/material.module.ts
@@ -1,0 +1,34 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import {MatButtonModule} from "@angular/material/button"
+import {MatCardModule} from "@angular/material/card"
+import {MatChipsModule} from "@angular/material/chips"
+import {MatDialogModule} from "@angular/material/dialog"
+import {MatDividerModule} from "@angular/material/divider"
+import {MatIconModule} from "@angular/material/icon"
+import {MatInputModule} from "@angular/material/input"
+import {MatProgressSpinnerModule} from "@angular/material/progress-spinner";
+import {MatSelectModule} from "@angular/material/select"
+import {MatSidenavModule} from "@angular/material/sidenav"
+import {MatSnackBarModule} from "@angular/material/snack-bar";
+import {MatToolbarModule} from "@angular/material/toolbar"
+
+@NgModule({
+  exports: [
+    CommonModule,
+    MatButtonModule,
+    MatCardModule,
+    MatChipsModule,
+    MatDialogModule,
+    MatDividerModule,
+    MatIconModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    MatSelectModule,
+    MatSidenavModule,
+    MatSnackBarModule,
+    MatToolbarModule,
+  ]
+})
+export class MaterialModule { }

--- a/frontend/src/app/modules/material/material.module.ts
+++ b/frontend/src/app/modules/material/material.module.ts
@@ -8,6 +8,7 @@ import {MatDialogModule} from "@angular/material/dialog"
 import {MatDividerModule} from "@angular/material/divider"
 import {MatIconModule} from "@angular/material/icon"
 import {MatInputModule} from "@angular/material/input"
+import {MatPaginatorModule} from "@angular/material/paginator";
 import {MatProgressSpinnerModule} from "@angular/material/progress-spinner";
 import {MatSelectModule} from "@angular/material/select"
 import {MatSidenavModule} from "@angular/material/sidenav"
@@ -24,6 +25,7 @@ import {MatToolbarModule} from "@angular/material/toolbar"
     MatDividerModule,
     MatIconModule,
     MatInputModule,
+    MatPaginatorModule,
     MatProgressSpinnerModule,
     MatSelectModule,
     MatSidenavModule,

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@900&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
 </head>
 <body class="mat-typography mat-app-background">
   <app-root></app-root>

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,6 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
 
-html, body { height: 100%; }
+html, body { height: 100%; overflow: hidden }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
 mat-form-field .mat-form-field-flex {


### PR DESCRIPTION
Closes #91 

**Pagination-related**
- [x] Add a [Paginator component](https://material.angular.io/components/paginator/overview) to the `internship-list` component
- [x] Only show the specified number of results on each page
- [x] When the next page button is clicked, retrieve the next load of internships via API service call (contextual based off if we're searching by query or just generally)
- [x] Moved all related Material-related imports into the `MaterialModule`  

**CSS-related**
- [x] Added [Bulma](https://bulma.io/), a CSS framework, to the project to help with layout and pre-built components
- [x] Disabled overflow on the main page so that 
- [x] Added overflow to the internship details and internship list components so they scroll _individually_, not together