### PR TITLE
add include/exclude company functionality

### DIFF
--- a/backend/__main__.py
+++ b/backend/__main__.py
@@ -20,6 +20,9 @@ def run_cli():
     parser.add_argument("--save-jobs", action="store_true")
     parser.add_argument("--run-as-proc", dest="multiprocessing", action="store_true")
     parser.add_argument("--dev", action="store_true")
+    company_modify_group = parser.add_mutually_exclusive_group()
+    company_modify_group.add_argument("--include-companies", nargs="+")
+    company_modify_group.add_argument("--exclude-companies", nargs="+")
     args = parser.parse_args()
 
     if args.dev:

--- a/backend/app/scraping/scraper.py
+++ b/backend/app/scraping/scraper.py
@@ -244,6 +244,12 @@ def scrape(args: Namespace):
         directory = abspath(join(__file__, pardir)) + "/../../../data/companies"
         for file in listdir(directory):
             filename = fsdecode(file)
+            # Include/exclude companies
+            company = filename.removesuffix(".json")
+            if (args.include_companies and company not in args.include_companies) or (
+                args.exclude_companies and company in args.exclude_companies
+            ):
+                continue
             file_dir_path = join(directory, filename)
             file_scrape_config_json = DataFile(
                 file_dir_path,


### PR DESCRIPTION
Closes #131 

- Adds `--include-companies` and `--exclude-companies` CLI args that take one or many companies to include/exclude while scraping
  - `--include-companies` and `--exclude-companies` are mutually exclusive, only exactly one arg (or none, but not both) can be defined
  - `--include-companies` will **only** scrape the (valid) companies defined in this argument
  - `--exclude-companies` will **exclude** the (valid) companies defined in this argument from scraping