### PR TITLE
AT-198: Update requirements.txt to include async_timeout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+async_timeout==4.0.3
 bcrypt==4.0.1
 celery[redis]
 fastapi==0.95.2


### PR DESCRIPTION
Closes #198

`async_timeout` version set to 4.0.3